### PR TITLE
Add Dockerfile and container instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Exclude virtual environments and Python cache
+venv
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+
+# Git and Docker files
+.git
+.gitignore
+.dockerignore
+
+# Jupyter checkpoints
+.ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ venv/
 *.dat
 
 # Docker artifacts
-Dockerfile
 docker-compose.yml
 *.docker
 *.img

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir jupyter
+
+COPY . .
+
+EXPOSE 8888
+
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--no-browser", "--allow-root"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ Alternatively, you can automate the above steps with:
 make install
 ```
 
+## Docker
+
+Build the image:
+```bash
+docker build -t dsp .
+```
+
+Run the container:
+```bash
+docker run -p 8888:8888 dsp
+```
+
+This starts a Jupyter Notebook server at http://localhost:8888.
+
 ## Contents
 ### Machine Learning
   [Predicting Boston Housing Prices:](https://github.com/Dislevekanku/datascienceprojects/blob/703d428e1739dca4832ede708f5880a8aa27b6ff/boston_housing/Boston%20Housing%20price%20prediction.ipynb) Used Linear Regression model to predict the value of houses in the Boston area, Used various statistical tools for analysis. Performed model evaluation by finding the r2 score.


### PR DESCRIPTION
## Summary
- add Dockerfile based on python:3.11-slim that installs dependencies and launches Jupyter Notebook
- add .dockerignore to reduce build context
- document Docker build/run instructions in README
- update .gitignore to allow tracking the Dockerfile

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: invalid character in `AI_Career_coach/file.py`)*
- `git ls-files '*.py' | grep -v AI_Career_coach/file.py | xargs -d '\n' python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68bca2e850e88325abd6684ed9789906