### PR TITLE
Add CI workflow for linting and Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+      - name: Run flake8
+        run: flake8
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build .


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies, run flake8, and build Docker image

## Testing
- `git ls-files '*.py' | tr '\n' '\0' | xargs -0 python -m py_compile` (fails: invalid character in AI_Career_coach/file.py)
- `git ls-files '*.py' | grep -v 'AI_Career_coach/file.py' | tr '\n' '\0' | xargs -0 python -m py_compile`
- `pip install pyyaml` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68be170508348325a8e110b8ab9dd7e4