### PR TITLE
Add pre-commit setup and contribution guidelines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -17,6 +17,27 @@ Alternatively, you can automate the above steps with:
 make install
 ```
 
+After setting up the environment, install the pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+## Contributing
+
+### Branch Naming
+- Use descriptive branch names prefixed with `feature/`, `fix/`, or `docs/`.
+- Separate words with hyphens, e.g., `feature/add-model-evaluation`.
+
+### Commit Messages
+- Use the imperative mood in the subject line.
+- Keep the subject line under 50 characters.
+
+### Pull Requests
+- Open PRs against the `main` branch.
+- Ensure all checks pass and request at least one review.
+- Address review feedback promptly.
+
 ## Docker
 
 Build the image:


### PR DESCRIPTION
## Summary
- document branch naming, commit message, and PR review guidelines
- add pre-commit configuration with Black and Flake8 hooks
- mention running `pre-commit install` during setup

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68be19f0643083258d836665b4c12538