### PR TITLE
Add synthetic oncology data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ This starts a Jupyter Notebook server at http://localhost:8888.
 
 
   [Building a Simple Language Model with Flask and NLTK](https://github.com/Dislevekanku/datascienceprojects/tree/master/LLM_FLASK) This repository details the implementation, testing, and evaluation of a simple n-gram language model using the NLTK library. The model is designed to predict the next word in a sentence based on the preceding words, using n-gram statistics. We explored both bigram (n=2) and trigram (n=3) models to compare their performance.
+
+  [Synthetic Oncology Data:](synthetic_oncology/README.md) Generate de-identified cancer patient records with Synthea and matching VCF variant profiles.

--- a/synthetic_oncology/README.md
+++ b/synthetic_oncology/README.md
@@ -1,0 +1,53 @@
+# Synthetic Oncology Data
+
+This project demonstrates how to generate de-identified oncology patient data
+using the [Synthea](https://github.com/synthetichealth/synthea) simulator and
+create accompanying genomic variant profiles.
+
+## Prerequisites
+
+- Java 8 or later
+- Git
+- Gradle (or use the Gradle wrapper from Synthea)
+
+## Generate Clinical Records
+
+Clone and build Synthea, then run it to produce cancer-specific patient data.
+
+```bash
+git clone https://github.com/synthetichealth/synthea.git
+cd synthea
+./gradlew run --args="-Ppopulation=10"  # Generates 10 patients
+```
+
+The exported FHIR JSON files will appear under `output/fhir/`.
+
+## Generate Variant Profiles
+
+Run the helper script to create a small set of cancer-related variants for each
+patient produced by Synthea:
+
+```bash
+python synthetic_oncology/make_variants.py
+```
+
+The script scans `output/fhir/` for patient IDs and writes corresponding VCF
+files to `output/vcf/`.
+
+Each VCF contains one to three randomly selected variants from a curated list of
+cancer-associated mutations.
+
+## Output Structure
+
+```
+output/
+├── fhir/
+│   ├── <patientID1>.json
+│   └── ...
+└── vcf/
+    ├── <patientID1>.vcf
+    └── ...
+```
+
+With this pipeline, every synthetic patient has both clinical records and an
+associated genomic variant profile.

--- a/synthetic_oncology/make_variants.py
+++ b/synthetic_oncology/make_variants.py
@@ -1,0 +1,49 @@
+import random
+from pathlib import Path
+
+# Known cancer-related variants (example subset)
+# Format: chromosome, position, reference, alternate, gene annotation
+CANCER_VARIANTS = [
+    ("17", 43125483, "T", "G", "BRCA1 p.Val1736Ala"),
+    ("13", 32906621, "C", "T", "BRCA2 p.Lys3326*"),
+    ("7", 55249071, "G", "A", "EGFR p.L858R"),
+    ("12", 25398285, "T", "G", "KRAS p.G12C"),
+]
+
+
+def write_vcf(
+    patient_id: str, variants: list[tuple[str, int, str, str, str]], outdir: str
+) -> None:
+    """Write selected variants to a VCF file for the patient."""
+    header = (
+        "##fileformat=VCFv4.2\n"
+        "##source=SyntheaVariantGenerator\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+    )
+    lines = [
+        f"{chrom}\t{pos}\t.\t{ref}\t{alt}\t.\tPASS\tGENE={gene}"
+        for chrom, pos, ref, alt, gene in variants
+    ]
+
+    path = Path(outdir) / f"{patient_id}.vcf"
+    path.write_text(header + "\n".join(lines) + "\n")
+
+
+def generate_for_patient(patient_id: str, outdir: str = "output/vcf") -> None:
+    """Generate 1–3 random cancer-related variants for a patient."""
+    Path(outdir).mkdir(parents=True, exist_ok=True)
+    num = random.randint(1, 3)
+    variants = random.sample(CANCER_VARIANTS, num)
+    write_vcf(patient_id, variants, outdir)
+
+
+def main() -> None:
+    """Create VCFs for all patients found in FHIR export directory."""
+    fhir_dir = Path("output/fhir")
+    for fhir_file in fhir_dir.glob("*.json"):
+        pid = fhir_file.stem
+        generate_for_patient(pid)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add synthetic_oncology project with script to create cancer-related VCF files for Synthea patients
- document workflow for generating de-identified clinical records and matching variants
- list synthetic oncology project in main README

## Testing
- `python synthetic_oncology/make_variants.py`
- `python -m black synthetic_oncology/make_variants.py`
- `pre-commit run --files synthetic_oncology/make_variants.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `flake8 synthetic_oncology/make_variants.py` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9f2489348325b210ce32cdac6b00