### PR TITLE
Add Trust-First agentic web explainer service

### DIFF
--- a/nanda-agent/.env.example
+++ b/nanda-agent/.env.example
@@ -1,0 +1,6 @@
+OPENAI_API_KEY=sk-***
+MODEL=gpt-4o-mini
+HOST=0.0.0.0
+PORT=8080
+# Optional if adapter needs a shared secret handshake
+NANDA_SHARED_SECRET=changeme

--- a/nanda-agent/README.md
+++ b/nanda-agent/README.md
@@ -1,0 +1,142 @@
+# Trust-First Agentic Web Explainer
+
+A LangChain-powered FastAPI service wrapped for the [NANDA adapter](https://github.com/projnanda/adapter). The agent focuses on MCP, A2A, and trust-first agentic web concepts, and can optionally fetch and summarize external URLs.
+
+## Project layout
+
+```
+nanda-agent/
+├─ adapter/                         # clone https://github.com/projnanda/adapter
+├─ app/
+│  ├─ main.py                       # FastAPI server (NANDA adapter wrapper)
+│  ├─ agent.py                      # LangChain agent logic
+│  ├─ tools.py                      # URL fetch/extract helper
+│  ├─ config.py                     # environment configuration
+│  ├─ prompts.py                    # system prompt definition
+│  └─ __init__.py
+├─ requirements.txt
+├─ .env.example
+└─ README.md
+```
+
+## Prerequisites
+
+* Python 3.10+
+* An OpenAI API key with access to `gpt-4o-mini` (or override `MODEL`)
+* (Optional) NANDA adapter cloned alongside the project
+
+## Local setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # update with your secrets
+```
+
+## Running locally
+
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8080
+```
+
+Check health:
+
+```bash
+curl -s http://127.0.0.1:8080/health
+```
+
+Test chat endpoint:
+
+```bash
+curl -X POST http://127.0.0.1:8080/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"In 3 bullets, what is MCP?"}]}'
+```
+
+## NANDA adapter integration
+
+1. Clone the adapter as a sibling directory inside `nanda-agent/adapter/`:
+
+   ```bash
+   git clone https://github.com/projnanda/adapter.git adapter
+   ```
+
+2. Follow the adapter README to configure its environment variables. Point the adapter at the FastAPI endpoint, e.g. `ADAPTER_TARGET_URL=http://127.0.0.1:8080/chat`.
+
+3. Start the adapter (for example via `uvicorn`, Docker, or the method specified by the repo) and obtain the NANDA chat URL it exposes.
+
+4. (Optional) Set `NANDA_SHARED_SECRET` in both the adapter and this service to enforce shared-secret auth on `/chat`.
+
+## Deployment to Ubuntu 22.04 (EC2 example)
+
+```bash
+sudo apt update && sudo apt -y install git python3.10-venv python3-pip nginx
+
+# clone repo
+cd /home/ubuntu
+git clone https://github.com/youruser/nanda-agent.git
+cd nanda-agent
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # add real secrets
+uvicorn app.main:app --host 0.0.0.0 --port 8080
+```
+
+Create `/etc/systemd/system/nanda-agent.service`:
+
+```
+[Unit]
+Description=Nanda Agent (Uvicorn)
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/home/ubuntu/nanda-agent
+Environment="PATH=/home/ubuntu/nanda-agent/.venv/bin"
+ExecStart=/home/ubuntu/nanda-agent/.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8080
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now nanda-agent
+sudo systemctl status nanda-agent
+```
+
+(Optional) Reverse proxy with Nginx:
+
+```
+server {
+  listen 80;
+  server_name _;
+
+  location / {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}
+```
+
+Link and reload:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/nanda /etc/nginx/sites-enabled/nanda
+sudo nginx -t
+sudo systemctl restart nginx
+```
+
+## Demo
+
+Record a short (~1 minute) screen capture that:
+
+1. Shows the FastAPI server running (either locally or on EC2).
+2. Demonstrates a `/chat` request, ideally via the NANDA adapter URL.
+3. Highlights URL ingestion by pasting a link and letting the agent summarize it with trust/interop insights.

--- a/nanda-agent/app/agent.py
+++ b/nanda-agent/app/agent.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from langchain.schema import AIMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+
+from .config import MODEL, OPENAI_API_KEY
+from .prompts import SYSTEM_PROMPT
+from .tools import fetch_and_extract
+
+
+class NandaAgent:
+    """Trust-first explainer agent orchestrated for the NANDA adapter."""
+
+    def __init__(self) -> None:
+        if not OPENAI_API_KEY:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        self.llm = ChatOpenAI(api_key=OPENAI_API_KEY, model=MODEL, temperature=0.2)
+
+    async def run(self, messages: List[Dict[str, Any]]) -> str:
+        """Execute the agent against a NANDA-formatted message history."""
+        user_text: Optional[str] = None
+        last_user_index: Optional[int] = None
+        for idx, message in enumerate(messages):
+            if message.get("role") == "user":
+                user_text = message.get("content", user_text)
+                last_user_index = idx
+
+        url: Optional[str] = None
+        if user_text:
+            import re
+
+            match = re.search(r"(https?://\S+)", user_text)
+            if match:
+                url = match.group(1)
+
+        fetched = ""
+        if url:
+            fetched = await fetch_and_extract(url)
+
+        prompt_blocks: List[SystemMessage | HumanMessage | AIMessage] = [
+            SystemMessage(content=SYSTEM_PROMPT)
+        ]
+
+        for idx, message in enumerate(messages):
+            role = message.get("role")
+            content = message.get("content", "")
+            if role == "system":
+                continue
+            if role == "assistant":
+                prompt_blocks.append(AIMessage(content=content))
+            elif role == "user":
+                if fetched and idx == last_user_index:
+                    prompt_blocks.append(
+                        HumanMessage(content=f"Fetched content from {url}:\n{fetched}")
+                    )
+                prompt_blocks.append(HumanMessage(content=content))
+
+        response = await self.llm.ainvoke(prompt_blocks)
+        return response.content

--- a/nanda-agent/app/config.py
+++ b/nanda-agent/app/config.py
@@ -1,0 +1,11 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+MODEL = os.getenv("MODEL", "gpt-4o-mini")
+HOST = os.getenv("HOST", "0.0.0.0")
+PORT = int(os.getenv("PORT", "8080"))
+# If NANDA adapter requires a specific secret or handshake, add here:
+NANDA_SHARED_SECRET = os.getenv("NANDA_SHARED_SECRET", "")

--- a/nanda-agent/app/main.py
+++ b/nanda-agent/app/main.py
@@ -1,0 +1,37 @@
+from fastapi import FastAPI, Header
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+from .agent import NandaAgent
+from .config import NANDA_SHARED_SECRET
+
+app = FastAPI(title="NANDA Adapter Wrapped Agent")
+agent = NandaAgent()
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: List[ChatMessage]
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/chat")
+async def chat(
+    req: ChatRequest,
+    x_nanda_secret: Optional[str] = Header(default=None),
+) -> Dict[str, Any]:
+    if NANDA_SHARED_SECRET and x_nanda_secret != NANDA_SHARED_SECRET:
+        return JSONResponse(status_code=401, content={"error": "unauthorized"})
+
+    messages: List[Dict[str, Any]] = [message.model_dump() for message in req.messages]
+    answer = await agent.run(messages)
+    return {"reply": answer}

--- a/nanda-agent/app/prompts.py
+++ b/nanda-agent/app/prompts.py
@@ -1,0 +1,7 @@
+SYSTEM_PROMPT = """You are the Trust-First Agentic Web Explainer.
+You specialize in MCP, A2A, agent interoperability, trust/reputation layers,
+Agentic Commerce, and Societies of Agents. You:
+- Are concise, citation-aware, and call tools when a URL is given.
+- Highlight trust, governance, and interoperability design choices.
+- Clearly mark assumptions and limitations.
+If user gives a URL, summarize and extract 3–5 insights with bullets."""

--- a/nanda-agent/app/tools.py
+++ b/nanda-agent/app/tools.py
@@ -1,0 +1,14 @@
+import httpx
+from bs4 import BeautifulSoup
+
+
+async def fetch_and_extract(url: str) -> str:
+    try:
+        async with httpx.AsyncClient(timeout=20) as client:
+            response = await client.get(url, follow_redirects=True)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "html.parser")
+            texts = [text.strip() for text in soup.stripped_strings]
+            return " ".join(texts)[:15000]
+    except Exception as exc:  # pragma: no cover - network-dependent
+        return f"[fetch_error] {exc}"

--- a/nanda-agent/requirements.txt
+++ b/nanda-agent/requirements.txt
@@ -8,3 +8,4 @@ beautifulsoup4==4.12.3
 python-dotenv==1.0.1
 tiktoken==0.7.0
 requests==2.32.3
+pytest==8.3.3

--- a/nanda-agent/requirements.txt
+++ b/nanda-agent/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.9.2
+langchain==0.2.13
+langchain-openai==0.1.23
+httpx==0.27.2
+beautifulsoup4==4.12.3
+python-dotenv==1.0.1
+tiktoken==0.7.0
+requests==2.32.3

--- a/nanda-agent/tests/test_app.py
+++ b/nanda-agent/tests/test_app.py
@@ -1,0 +1,40 @@
+import os
+import types
+
+import pytest
+
+
+fastapi = pytest.importorskip("fastapi")
+
+# Ensure required environment variables exist before importing the app
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from fastapi.testclient import TestClient
+
+from app import main
+
+
+async def _fake_run(self, messages):
+    """Deterministic agent stub for testing."""
+    # store the last messages for assertions if needed
+    self._last_messages = messages
+    return "stubbed reply"
+
+
+main.agent.run = types.MethodType(_fake_run, main.agent)
+
+client = TestClient(main.app)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_chat_returns_agent_response():
+    payload = {"messages": [{"role": "user", "content": "Hello"}]}
+    response = client.post("/chat", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"reply": "stubbed reply"}
+    assert getattr(main.agent, "_last_messages") == payload["messages"]


### PR DESCRIPTION
## Summary
- add LangChain-powered Trust-First agent implementation with URL fetching and FastAPI adapter endpoint
- provide project configuration, prompts, and requirements for deploying the agent service
- document setup, adapter integration, and deployment instructions for the NANDA wrapper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe912a1c88325a527f6c15d749350